### PR TITLE
Use workers to limit concurrency by work stealing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +496,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1231,7 +1307,9 @@ dependencies = [
 name = "yt-sync"
 version = "0.0.1"
 dependencies = [
+ "crossbeam",
  "futures",
+ "num_cpus",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +154,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -312,6 +345,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -358,6 +400,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -487,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -674,6 +722,23 @@ checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
@@ -869,6 +934,15 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1128,6 +1202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,7 +1391,9 @@ name = "yt-sync"
 version = "0.0.1"
 dependencies = [
  "crossbeam",
+ "env_logger",
  "futures",
+ "log",
  "num_cpus",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
+crossbeam = "0.8.0"
+num_cpus = "1.15.0"
 futures = "0.3.28"
 tokio = { version = "1", features = ["full"] }
 youtube_dl = { version = "0.8.1", features = ["tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
+env_logger = "0.9.0"
+log = "0.4.19"
 crossbeam = "0.8.0"
 num_cpus = "1.15.0"
 futures = "0.3.28"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
 extern crate crossbeam;
 
-use crossbeam::channel::bounded;
+use crossbeam::channel::unbounded;
+use env_logger::Env;
+use futures::future::join_all;
+use log::{debug, info, warn};
 use serde::Deserialize;
 use std::error::Error;
 use std::fmt::Display;
 use std::fs;
+use tokio::task::JoinHandle;
 
 use youtube_dl::YoutubeDlOutput::Playlist;
 use youtube_dl::{SingleVideo, YoutubeDl};
@@ -26,43 +30,71 @@ fn make_archive_file_path(channel_id: &str) -> String {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    let env = Env::default().filter_or("RUST_LOG", "info");
+    env_logger::init_from_env(env);
+
     // Read the channel URLs from a JSON file
     let channel_file = fs::read_to_string("channels.json")?;
     let channels: Vec<Channel> = serde_json::from_str(&channel_file)?;
 
-    let (tx, rx) = bounded::<ChannelVideoMessage>(16);
-
+    let (tx, rx) = unbounded::<ChannelVideoMessage>();
+    let mut channel_handles: Vec<JoinHandle<()>> = Vec::with_capacity(channels.len());
     for channel in channels {
-        let tx = tx.clone();
-        tokio::spawn(async move {
+        info!("Spawning thread to get videos from {}.", channel.url);
+        let channel_video_tx = tx.clone();
+        channel_handles.push(tokio::spawn(async move {
+            info!("Getting videos from {}.", channel.url);
             let messages = get_videos_from_channel(&channel).await.unwrap();
+            info!("Got {} videos from {}.", messages.len(), channel.url);
             if !messages.is_empty() {
                 let channel_id = get_channel_id(&channel).unwrap();
                 let archive_file = make_archive_file_path(channel_id);
                 if !std::path::Path::new(&archive_file).exists() {
+                    info!("Creating archive file at {}.", archive_file);
                     fs::create_dir_all(format!("archives/{}", channel_id)).unwrap();
                     fs::write(&archive_file, "").unwrap();
                 }
             }
             for m in messages {
-                tx.send(m).unwrap();
+                let video_id = m.video.id.clone();
+                debug!("Sending video message {}.", m.video.id);
+                match channel_video_tx.send(m) {
+                    Ok(_) => debug!("Sent video message {}.", video_id),
+                    Err(e) => warn!(
+                        "Failed to send video message {} from channel {}. Error: {}",
+                        video_id, channel.url, e
+                    ),
+                };
             }
-            drop(tx);
-        });
+            drop(channel_video_tx);
+        }));
     }
 
     drop(tx);
+    join_all(channel_handles).await;
 
     let workers = num_cpus::get();
-    for _ in 0..workers {
-        let rx = rx.clone();
-        tokio::spawn(async move {
-            for m in rx.iter() {
-                // TODO Error handling
-                download_video(m).unwrap();
+    info!("Spawning {} worker threads.", workers);
+    let mut worker_handles: Vec<JoinHandle<()>> = Vec::with_capacity(workers);
+    for worker_id in 0..workers {
+        let worker_rx = rx.clone();
+        worker_handles.push(tokio::spawn(async move {
+            info!("Worker {} reporting for duty.", worker_id);
+            for m in worker_rx.iter() {
+                let video_id = m.video.id.clone();
+                match download_video(m) {
+                    Ok(_) => debug!("Worker {} downloaded video {}.", worker_id, video_id),
+                    Err(e) => warn!(
+                        "Worker {} failed to download video {}. Error: {}",
+                        worker_id, video_id, e
+                    ),
+                };
             }
-        });
+            info!("Worker {} 🫡  signing off.", worker_id);
+        }));
     }
+
+    join_all(worker_handles).await;
 
     Ok(())
 }
@@ -108,7 +140,13 @@ async fn get_videos_from_channel(
         .await?
     {
         Playlist(playlist) => {
+            info!("Found playlist for channel {}.", channel.url);
             if let Some(single_videos) = playlist.entries {
+                info!(
+                    "Found {} videos for channel {}.",
+                    single_videos.len(),
+                    channel.url
+                );
                 single_videos
                     .into_iter()
                     .map(|single_video| ChannelVideoMessage {
@@ -117,10 +155,14 @@ async fn get_videos_from_channel(
                     })
                     .collect::<Vec<ChannelVideoMessage>>()
             } else {
+                warn!("The playlist for channel {} has no videos.", channel.url);
                 vec![]
             }
         }
-        _ => vec![],
+        _ => {
+            warn!("No videos found for channel {}.", channel.url);
+            vec![]
+        }
     };
 
     Ok(videos)
@@ -128,14 +170,19 @@ async fn get_videos_from_channel(
 
 fn download_video(cvm: ChannelVideoMessage) -> Result<(), Box<dyn Error>> {
     if let Some(video_url) = cvm.video.url {
+        info!("Downloading video {} from {}.", video_url, cvm.channel_id);
         YoutubeDl::new(video_url)
             .format("mp4")
             .download(true)
-            // todo put the date of the video in the title
-            .output_template("channels/%(channel)s/%(title)s.mp4")
+            // When viewing channels by directory in Plex the videos are sorted by file name.
+            // Plex doesn't offer any other sorting options, so adding the upload date as a prefix
+            // on the filename is an 80% solution here. Not great, but it works!
+            .output_template("channels/%(channel)s/%(upload_date>%Y-%m-%d)s - %(title)s.mp4")
             .extra_arg("--download-archive")
             .extra_arg(make_archive_file_path(cvm.channel_id.as_str()))
             .run()?;
+    } else {
+        warn!("Video {} from {} has no URL! Unable to download.", cvm.video.id, cvm.channel_id);
     }
     Ok(())
 }


### PR DESCRIPTION
Use an unbounded multiple-producer multi-consumer (from crossbeam) to spawn a worker thread for each CPU (from num_cpus) to limit concurrency.